### PR TITLE
Fix classpath separator in windows

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,6 +3,7 @@
 
 var exec = require('child_process').exec;
 var path = require('path');
+var cpSeparator = require('os').type().match(/^win/i) ? ";" : ":";
 
 module.exports = function (options) {
   var defaults = options || {};
@@ -21,7 +22,7 @@ module.exports = function (options) {
   }
   return {
     decode: function(filePath, cb) {
-      exec('java -cp '+path.join(defaults.ZXingLocation, 'javase', 'javase'+defaults.ZXingVersion+'.jar')+':'+path.join(defaults.ZXingLocation, 'core', 'core'+defaults.ZXingVersion+'.jar')+' com.google.zxing.client.j2se.CommandLineRunner'+commandLineOptions+''+filePath,
+      exec('java -cp '+path.join(defaults.ZXingLocation, 'javase', 'javase'+defaults.ZXingVersion+'.jar')+cpSeparator+path.join(defaults.ZXingLocation, 'core', 'core'+defaults.ZXingVersion+'.jar')+' com.google.zxing.client.j2se.CommandLineRunner'+commandLineOptions+''+filePath,
         function(err, stdout, stderr){
           var qrcode = "";
           var errorCache = null;


### PR DESCRIPTION
Java CLASSPATH separator is ";" in windows.
I added windows style CLASSPATH seprator support.
